### PR TITLE
Remove android platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "typings": "index.d.ts",
   "nativescript": {
     "platforms": {
-      "android": "2.3.0",
       "ios": "2.3.0"
     }
   },


### PR DESCRIPTION
This plugin is iOS only and android platform key should be removed.